### PR TITLE
修复 Star History 图表显示问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ jsDelivr 可能存在最长 24 小时缓存，因此规则更新会有延迟。
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=qxzg/Actions&type=Date)](https://star-history.com/#qxzg/Actions&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=qxzg/Actions&type=Date)](https://star-history.dera.page/#qxzg/Actions&Date)


### PR DESCRIPTION
当前 Star History 图表由于 GitHub stargazer API 的限制已经无法正常显示，需要修复。本 PR 将图表地址切换到 star-history.dera.page，并使用无需 API token 的替代数据源，使图表恢复可用。